### PR TITLE
[s:jira t:17076] Add extra_resources field in compute_node

### DIFF
--- a/nova/api/openstack/compute/hypervisors.py
+++ b/nova/api/openstack/compute/hypervisors.py
@@ -55,7 +55,7 @@ class HypervisorsController(wsgi.Controller):
                           'hypervisor_type', 'hypervisor_version',
                           'free_ram_mb', 'free_disk_gb', 'current_workload',
                           'running_vms', 'cpu_info', 'disk_available_least',
-                          'host_ip'):
+                          'host_ip', 'extra_resources'):
                 hyp_dict[field] = hypervisor[field]
 
             hyp_dict['service'] = {

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -5378,6 +5378,10 @@ class LibvirtDriver(driver.ComputeDriver):
         data["hypervisor_type"] = self._host.get_driver_type()
         data["hypervisor_version"] = self._host.get_version()
         data["hypervisor_hostname"] = self._host.get_hostname()
+        data["extra_resources"] = self._get_host_sysinfo_serial_hardware()
+
+        LOG.debug('Host uuid to be set to extra_resources %s' %self._get_host_sysinfo_serial_hardware())
+
         # TODO(berrange): why do we bother converting the
         # libvirt capabilities XML into a special JSON format ?
         # The data format is different across all the drivers


### PR DESCRIPTION
Add extra_resources field in compute_node to store hypervisor uuid and associated changed to libvirt driver to extra the bios uuid.